### PR TITLE
Add missing line to ensure order status table is created.

### DIFF
--- a/helpers/LinksynceparcelHelper.php
+++ b/helpers/LinksynceparcelHelper.php
@@ -277,6 +277,8 @@ class LinksynceparcelHelper
 			PRIMARY KEY  (`id`)
 		  );";
 
+		dbDelta( $sql );
+
 		$table_name = $wpdb->prefix . "linksynceparcel_consignment_temp_cost";
 		$sql = "CREATE TABLE IF NOT EXISTS `$table_name` (
 			`order_id` int(11) NOT NULL DEFAULT '0',
@@ -4853,7 +4855,7 @@ class LinksynceparcelHelper
 		{
 			$article = array();
 			$articles = LinksynceparcelValidator::get_article_preset($articles_type);
-            
+
 			$article['description'] = $articles[0];
 			$article['weight'] = $articles[1];
             $use_dimension = (int)get_option('linksynceparcel_use_dimension');


### PR DESCRIPTION
I have a client using a Trial of your WooCommerce extension on their website, and I noticed the error log growing to enormous sizes. When I checked the log I noticed hundreds of these errors:

> [20-Dec-2018 02:37:43 UTC] WordPress database error Table '...wp_linksynceparcel_order_statuses' doesn't exist for query SELECT `status` FROM wp_linksynceparcel_order_statuses WHERE status='wc-failed' made by require_once('wp-load.php'), require_once('wp-config.php'), require_once('wp-settings.php'), do_action('plugins_loaded'), WP_Hook->do_action, WP_Hook->apply_filters, linksynceparcel_init, LinksynceparcelHelper::saveOrderStatuses, LinksynceparcelHelper::checkOrderStatus

When I checked the database I confirmed that the `wp_linksynceparcel_order_statuses` table did indeed not exist. In inspecting the code for your plugin I found that in the `LinksynceparcelHelper::createNewTables()` function there is SQL for the creating of this table on line `273` of the class file, but the `dbDelta( $sql )` line is missing, so this table is never created. 

This pull request adds that line.